### PR TITLE
Comment out MessageType

### DIFF
--- a/types/types.proto
+++ b/types/types.proto
@@ -10,22 +10,22 @@ package types;
 // Could be added to request/response
 // so we don't have to type switch
 // (would be twice as fast, but we're talking about 15ns)
-enum MessageType {
-	NullMessage = 0x00;
+// enum MessageType {
+// 	NullMessage = 0x00;
 
-	Echo            = 0x01;
-	Flush           = 0x02;
-	Info            = 0x03;
-	SetOption       = 0x04;
-	Exception       = 0x05;
-	DeliverTx       = 0x11;
-	CheckTx         = 0x12;
-	Commit          = 0x13;
-	Query           = 0x14;
-	InitChain       = 0x15;
-	BeginBlock      = 0x16;
-	EndBlock        = 0x17;
-}
+// 	Echo            = 0x01;
+// 	Flush           = 0x02;
+// 	Info            = 0x03;
+// 	SetOption       = 0x04;
+// 	Exception       = 0x05;
+// 	DeliverTx       = 0x11;
+// 	CheckTx         = 0x12;
+// 	Commit          = 0x13;
+// 	Query           = 0x14;
+// 	InitChain       = 0x15;
+// 	BeginBlock      = 0x16;
+// 	EndBlock        = 0x17;
+// }
 
 //----------------------------------------
 // Code types


### PR DESCRIPTION
As it is an unused enum, leaving it uncommented causes dead Protocol Buffers code to be generated.