### PR TITLE
Do not start client and server upon creation

### DIFF
--- a/client/grpc_client.go
+++ b/client/grpc_client.go
@@ -33,8 +33,7 @@ func NewGRPCClient(addr string, mustConnect bool) (*grpcClient, error) {
 		mustConnect: mustConnect,
 	}
 	cli.BaseService = *cmn.NewBaseService(nil, "grpcClient", cli)
-	_, err := cli.Start() // Just start it, it's confusing for callers to remember to start.
-	return cli, err
+	return cli, nil
 }
 
 func dialerFunc(addr string, timeout time.Duration) (net.Conn, error) {

--- a/client/socket_client.go
+++ b/client/socket_client.go
@@ -53,10 +53,7 @@ func NewSocketClient(addr string, mustConnect bool) (*socketClient, error) {
 		resCb:   nil,
 	}
 	cli.BaseService = *cmn.NewBaseService(nil, "socketClient", cli)
-	// FIXME we are loosing "Starting socketClient" message here
-	// add logger to params?
-	_, err := cli.Start() // Just start it, it's confusing for callers to remember to start.
-	return cli, err
+	return cli, nil
 }
 
 func (cli *socketClient) OnStart() error {

--- a/cmd/abci-cli/abci-cli.go
+++ b/cmd/abci-cli/abci-cli.go
@@ -149,6 +149,7 @@ func before(c *cli.Context) error {
 			os.Exit(1)
 		}
 		client.SetLogger(logger.With("module", "abci-client"))
+		client.Start()
 	}
 	return nil
 }

--- a/cmd/counter/main.go
+++ b/cmd/counter/main.go
@@ -27,6 +27,7 @@ func main() {
 		os.Exit(1)
 	}
 	srv.SetLogger(logger.With("module", "abci-server"))
+	srv.Start()
 
 	// Wait forever
 	cmn.TrapSignal(func() {

--- a/cmd/dummy/main.go
+++ b/cmd/dummy/main.go
@@ -36,6 +36,7 @@ func main() {
 		os.Exit(1)
 	}
 	srv.SetLogger(logger.With("module", "abci-server"))
+	srv.Start()
 
 	// Wait forever
 	cmn.TrapSignal(func() {

--- a/example/block_aware/block_aware_test.go
+++ b/example/block_aware/block_aware_test.go
@@ -20,6 +20,7 @@ func TestChainAware(t *testing.T) {
 		t.Fatal(err)
 	}
 	srv.SetLogger(log.TestingLogger().With("module", "abci-server"))
+	srv.Start()
 	defer srv.Stop()
 
 	// Connect to the socket

--- a/example/dummy/dummy_test.go
+++ b/example/dummy/dummy_test.go
@@ -219,6 +219,7 @@ func makeSocketClientServer(app types.Application, name string) (abcicli.Client,
 		return nil, nil, err
 	}
 	server.SetLogger(logger.With("module", "abci-server"))
+	server.Start()
 
 	// Connect to the socket
 	client, err := abcicli.NewSocketClient(socket, false)
@@ -243,6 +244,7 @@ func makeGRPCClientServer(app types.Application, name string) (abcicli.Client, c
 		return nil, nil, err
 	}
 	server.SetLogger(logger.With("module", "abci-server"))
+	server.Start()
 
 	client, err := abcicli.NewGRPCClient(socket, true)
 	if err != nil {
@@ -250,6 +252,7 @@ func makeGRPCClientServer(app types.Application, name string) (abcicli.Client, c
 		return nil, nil, err
 	}
 	client.SetLogger(logger.With("module", "abci-client"))
+	client.Start()
 	return client, server, err
 }
 

--- a/example/example_test.go
+++ b/example/example_test.go
@@ -43,6 +43,7 @@ func testStream(t *testing.T, app types.Application) {
 		t.Fatalf("Error starting socket server: %v", err.Error())
 	}
 	server.SetLogger(log.TestingLogger().With("module", "abci-server"))
+	server.Start()
 	defer server.Stop()
 
 	// Connect to the socket
@@ -117,6 +118,7 @@ func testGRPCSync(t *testing.T, app *types.GRPCApplication) {
 		t.Fatalf("Error starting GRPC server: %v", err.Error())
 	}
 	server.SetLogger(log.TestingLogger().With("module", "abci-server"))
+	server.Start()
 	defer server.Stop()
 
 	// Connect to the socket

--- a/server/grpc_server.go
+++ b/server/grpc_server.go
@@ -33,8 +33,7 @@ func NewGRPCServer(protoAddr string, app types.ABCIApplicationServer) (cmn.Servi
 		app:      app,
 	}
 	s.BaseService = *cmn.NewBaseService(nil, "ABCIServer", s)
-	_, err := s.Start() // Just start it
-	return s, err
+	return s, nil
 }
 
 func (s *GRPCServer) OnStart() error {

--- a/server/socket_server.go
+++ b/server/socket_server.go
@@ -40,10 +40,7 @@ func NewSocketServer(protoAddr string, app types.Application) (cmn.Service, erro
 		conns:    make(map[int]net.Conn),
 	}
 	s.BaseService = *cmn.NewBaseService(nil, "ABCIServer", s)
-	// FIXME we are loosing "Starting ABCIServer" message here
-	// add logger to params?
-	_, err := s.Start() // Just start it
-	return s, err
+	return s, nil
 }
 
 func (s *SocketServer) OnStart() error {

--- a/tests/test_app/app.go
+++ b/tests/test_app/app.go
@@ -40,6 +40,7 @@ func startClient(abciType string) abcicli.Client {
 	}
 	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 	client.SetLogger(logger.With("module", "abcicli"))
+	client.Start()
 	return client
 }
 

--- a/tests/test_cli/test.sh
+++ b/tests/test_cli/test.sh
@@ -16,7 +16,7 @@ function testExample() {
 	echo "Example $N"
 	$APP &> /dev/null &
 	sleep 2
-	abci-cli --verbose batch < "$INPUT" > "${INPUT}.out.new"
+	abci-cli --verbose batch < "$INPUT" | sed -n '1!p' > "${INPUT}.out.new"
 	killall "$APP"
 
 	pre=$(shasum < "${INPUT}.out")


### PR DESCRIPTION
Reasoning:

1. It is confusing since most of our Services do not start themselves 
2. If we do not pass logger to constructor, then we miss "starting ..."
(and probably other) messages