### PR TITLE
socketClient: fix and test for StopForError deadlock

### DIFF
--- a/client/socket_client.go
+++ b/client/socket_client.go
@@ -97,11 +97,11 @@ func (cli *socketClient) OnStop() {
 
 // Stop the client and set the error
 func (cli *socketClient) StopForError(err error) {
-	cli.mtx.Lock()
 	if !cli.IsRunning() {
 		return
 	}
 
+	cli.mtx.Lock()
 	if cli.err == nil {
 		cli.err = err
 	}

--- a/client/socket_client_test.go
+++ b/client/socket_client_test.go
@@ -1,0 +1,28 @@
+package abcicli_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tendermint/abci/client"
+)
+
+func TestSocketClientStopForErrorDeadlock(t *testing.T) {
+	c := abcicli.NewSocketClient(":80", false)
+	err := errors.New("foo-tendermint")
+
+	// See Issue https://github.com/tendermint/abci/issues/114
+	doneChan := make(chan bool)
+	go func() {
+		defer close(doneChan)
+		c.StopForError(err)
+		c.StopForError(err)
+	}()
+
+	select {
+	case <-doneChan:
+	case <-time.After(time.Second * 4):
+		t.Fatalf("Test took too long, potential deadlock still exists")
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/tendermint/abci/issues/114.

Fix and test for StopForError deadlock due to accidental
Mutex misuse. The test should return instantenously if
StopForError works without erraneous contention, lest it regressed.