### PR TITLE
Check for a two part, protocol provided, addr

### DIFF
--- a/client/socket_client.go
+++ b/client/socket_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -59,6 +60,10 @@ func NewSocketClient(addr string, mustConnect bool) *socketClient {
 func (cli *socketClient) OnStart() error {
 	if err := cli.BaseService.OnStart(); err != nil {
 		return err
+	}
+
+	if len(strings.SplitN(cli.addr, "://", 2)) < 2 {
+		return fmt.Error("Missing protocol provided (ex. tcp://)", cli.addr)
 	}
 
 	var err error

--- a/client/socket_client.go
+++ b/client/socket_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -57,6 +58,10 @@ func NewSocketClient(addr string, mustConnect bool) *socketClient {
 }
 
 func (cli *socketClient) OnStart() error {
+
+	if len(strings.SplitN(cli.addr, "://", 2)) < 2 {
+		return fmt.Errorf("Missing protocol (ex. tcp://) in %v", cli.addr)
+	}
 
 	if err := cli.BaseService.OnStart(); err != nil {
 		return err

--- a/client/socket_client.go
+++ b/client/socket_client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"reflect"
-	"strings"
 	"sync"
 	"time"
 
@@ -58,12 +57,9 @@ func NewSocketClient(addr string, mustConnect bool) *socketClient {
 }
 
 func (cli *socketClient) OnStart() error {
+
 	if err := cli.BaseService.OnStart(); err != nil {
 		return err
-	}
-
-	if len(strings.SplitN(cli.addr, "://", 2)) < 2 {
-		return fmt.Error("Missing protocol provided (ex. tcp://)", cli.addr)
 	}
 
 	var err error

--- a/client/socket_client_test.go
+++ b/client/socket_client_test.go
@@ -1,0 +1,18 @@
+package abcicli
+
+import (
+	"testing"
+
+	abcicli "github.com/tendermint/abci/client"
+)
+
+func TestSocketComponentParsing(t *testing.T) {
+	socket := "127.0.0.1:46658"
+
+	// Create socket client
+	client := abcicli.NewSocketClient(socket, true)
+	err := client.OnStart()
+	if err.Error() != "Missing protocol (ex. tcp://) in 127.0.0.1:46658" {
+		t.Fatalf("Expected protocol parsing to fail: %s", err.Error())
+	}
+}


### PR DESCRIPTION
Closes #72 

Since the included lib (go-common) is deprecated, and updated tmlibs contains the proper check, handle here until new tmlibs can be used exclusively.

https://github.com/tendermint/go-common/blob/47e06734f6ee488cc2e61550a38642025e1d4227/net.go#L11