### PR TITLE
cmd/abci-cli: use a single connection per session

### DIFF
--- a/cmd/abci-cli/abci-cli.go
+++ b/cmd/abci-cli/abci-cli.go
@@ -347,12 +347,6 @@ func cmdTest(cmd *cobra.Command, args []string) error {
 func cmdBatch(cmd *cobra.Command, args []string) error {
 	bufReader := bufio.NewReader(os.Stdin)
 	for {
-		// TODO:  (@ebuchman, @zramsay, @odeke-em) Implement the actual batch logic
-		printResponse(cmd, args, response{
-			Code: codeBad,
-			Log:  "Unimplemented",
-		})
-		return nil
 
 		line, more, err := bufReader.ReadLine()
 		if more {
@@ -364,6 +358,15 @@ func cmdBatch(cmd *cobra.Command, args []string) error {
 		} else if err != nil {
 			return err
 		}
+
+		if len(line) > 0 { // prevents introduction of extra space leading to argument parse errors
+			args = strings.Split(string(line), " ")
+		}
+
+		if err := muxOnCommands(cmd, args); err != nil {
+			return err
+		}
+		fmt.Println("")
 	}
 	return nil
 }
@@ -394,14 +397,22 @@ var (
 )
 
 func muxOnCommands(cmd *cobra.Command, pArgs []string) error {
-	if len(pArgs) < 2 {
+
+	if len(pArgs) < 1 && cmd.Use != "batch" {
 		return errBadPersistentArgs
 	}
 
-	subCommand, actualArgs := pArgs[1], pArgs[2:]
+	subCommand, actualArgs := pArgs[0], pArgs[1:]
+
+	//if cmd.Use == "batch" {
+	//	cmd.Use = subCommand
+	//}
+
+
 	switch strings.ToLower(subCommand) {
 	case "batch":
-		return cmdBatch(cmd, actualArgs)
+		fmt.Println("WTF")
+		return nil
 	case "check_tx":
 		return cmdCheckTx(cmd, actualArgs)
 	case "commit":

--- a/cmd/abci-cli/abci-cli.go
+++ b/cmd/abci-cli/abci-cli.go
@@ -387,15 +387,9 @@ func cmdConsole(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-var (
-	errBadPersistentArgs = errors.New("expecting persistent args of the form: abci-cli [command] <...>")
-
-	errUnimplemented = errors.New("unimplemented")
-)
-
 func muxOnCommands(cmd *cobra.Command, pArgs []string) error {
 	if len(pArgs) < 2 {
-		return errBadPersistentArgs
+		return errors.New("expecting persistent args of the form: abci-cli [command] <...>")
 	}
 	subCommand, actualArgs := pArgs[1], pArgs[2:]
 

--- a/tests/server/client.go
+++ b/tests/server/client.go
@@ -21,7 +21,7 @@ func InitChain(client abcicli.Client) error {
 	}
 	_, err := client.InitChainSync(types.RequestInitChain{Validators: vals})
 	if err != nil {
-		fmt.Println("Failed test: InitChain - %v", err)
+		fmt.Printf("Failed test: InitChain - %v\n", err)
 		return err
 	}
 	fmt.Println("Passed test: InitChain")
@@ -46,7 +46,7 @@ func Commit(client abcicli.Client, hashExp []byte) error {
 	_, data := res.Code, res.Data
 	if err != nil {
 		fmt.Println("Failed test: Commit")
-		fmt.Printf("committing %v\nlog: %v", res.GetLog())
+		fmt.Printf("committing %v\nlog: %v\n", res.GetLog(), err)
 		return err
 	}
 	if !bytes.Equal(data, hashExp) {


### PR DESCRIPTION
Use the single client connection at startup time
for sending over commands instead of shelling out
for every command.
This code fixes the regression from
https://github.com/tendermint/abci/pull/117
which instead used "os/exec".Command with:
    "abci-cli <the_command> [args...]"

The purpose of this code is to restore us
back to the state after cobra replace urlfave/cli.
There is still a bit of work to implement Batch
itself, but that should be simpler as a focused
command.

Fixes #133