### PR TITLE
server: log unenumerated/unexpected error in waitForClose

### DIFF
--- a/server/socket_server.go
+++ b/server/socket_server.go
@@ -130,14 +130,14 @@ func (s *SocketServer) waitForClose(closeConn chan error, connID int) {
 	if err == io.EOF {
 		s.Logger.Error("Connection was closed by client")
 	} else if err != nil {
-		s.Logger.Error("Connection error", "error", err)
+		s.Logger.Error("Connection error", "err", err)
 	} else {
-		s.Logger.Error("Unexpected error", "error", err)
+		s.Logger.Error("Unexpected error", "err", err)
 	}
 
 	// Close the connection
 	if err := s.rmConn(connID); err != nil {
-		s.Logger.Error("Error in closing connection", "error", err)
+		s.Logger.Error("Error in closing connection", "err", err)
 	}
 }
 

--- a/server/socket_server.go
+++ b/server/socket_server.go
@@ -132,8 +132,7 @@ func (s *SocketServer) waitForClose(closeConn chan error, connID int) {
 	} else if err != nil {
 		s.Logger.Error("Connection error", "error", err)
 	} else {
-		// never happens
-		s.Logger.Error("Connection was closed.")
+		s.Logger.Error("Unexpected error", "error", err)
 	}
 
 	// Close the connection


### PR DESCRIPTION
Log the unenumerated error in the (*SocketServer).waitForClose
routine, instead of providing a generic message
"Connection was closed", provide some more context.

Also, the comment previously on that line suggested that
an unenumerated error "never happens" but actually
the code in:
* handleRequests will error if a malformed message was sent
* handleResponses, the only used errors are not just io.EOF
errors but actually custom errors related to problems serializing
the message as well as failing to flush the message