### PR TITLE
all: fix vet issues with build tags, formatting

### DIFF
--- a/tests/server/client.go
+++ b/tests/server/client.go
@@ -21,7 +21,7 @@ func InitChain(client abcicli.Client) error {
 	}
 	_, err := client.InitChainSync(types.RequestInitChain{Validators: vals})
 	if err != nil {
-		fmt.Println("Failed test: InitChain - %v", err)
+		fmt.Printf("Failed test: InitChain - %v\n", err)
 		return err
 	}
 	fmt.Println("Passed test: InitChain")
@@ -46,7 +46,7 @@ func Commit(client abcicli.Client, hashExp []byte) error {
 	_, data := res.Code, res.Data
 	if err != nil {
 		fmt.Println("Failed test: Commit")
-		fmt.Printf("committing %v\nlog: %v", res.GetLog())
+		fmt.Printf("committing %v\nlog: %v", data, res.GetLog())
 		return err
 	}
 	if !bytes.Equal(data, hashExp) {

--- a/tests/server/client.go
+++ b/tests/server/client.go
@@ -33,7 +33,7 @@ func SetOption(client abcicli.Client, key, value string) error {
 	log := res.GetLog()
 	if err != nil {
 		fmt.Println("Failed test: SetOption")
-		fmt.Printf("setting %v=%v: \nlog: %v", key, value, log)
+		fmt.Printf("setting %v=%v: \nlog: %v\n", key, value, log)
 		fmt.Println("Failed test: SetOption")
 		return err
 	}
@@ -46,12 +46,12 @@ func Commit(client abcicli.Client, hashExp []byte) error {
 	_, data := res.Code, res.Data
 	if err != nil {
 		fmt.Println("Failed test: Commit")
-		fmt.Printf("committing %v\nlog: %v", data, res.GetLog())
+		fmt.Printf("committing %v\nlog: %v\n", data, res.GetLog())
 		return err
 	}
 	if !bytes.Equal(data, hashExp) {
 		fmt.Println("Failed test: Commit")
-		fmt.Printf("Commit hash was unexpected. Got %X expected %X",
+		fmt.Printf("Commit hash was unexpected. Got %X expected %X\n",
 			data.Bytes(), hashExp)
 		return errors.New("CommitTx failed")
 	}
@@ -64,13 +64,13 @@ func DeliverTx(client abcicli.Client, txBytes []byte, codeExp uint32, dataExp []
 	code, data, log := res.Code, res.Data, res.Log
 	if code != codeExp {
 		fmt.Println("Failed test: DeliverTx")
-		fmt.Printf("DeliverTx response code was unexpected. Got %v expected %v. Log: %v",
+		fmt.Printf("DeliverTx response code was unexpected. Got %v expected %v. Log: %v\n",
 			code, codeExp, log)
 		return errors.New("DeliverTx error")
 	}
 	if !bytes.Equal(data, dataExp) {
 		fmt.Println("Failed test: DeliverTx")
-		fmt.Printf("DeliverTx response data was unexpected. Got %X expected %X",
+		fmt.Printf("DeliverTx response data was unexpected. Got %X expected %X\n",
 			data, dataExp)
 		return errors.New("DeliverTx error")
 	}
@@ -83,13 +83,13 @@ func CheckTx(client abcicli.Client, txBytes []byte, codeExp uint32, dataExp []by
 	code, data, log := res.Code, res.Data, res.Log
 	if code != codeExp {
 		fmt.Println("Failed test: CheckTx")
-		fmt.Printf("CheckTx response code was unexpected. Got %v expected %v. Log: %v",
+		fmt.Printf("CheckTx response code was unexpected. Got %v expected %v. Log: %v\n",
 			code, codeExp, log)
 		return errors.New("CheckTx")
 	}
 	if !bytes.Equal(data, dataExp) {
 		fmt.Println("Failed test: CheckTx")
-		fmt.Printf("CheckTx response data was unexpected. Got %X expected %X",
+		fmt.Printf("CheckTx response data was unexpected. Got %X expected %X\n",
 			data, dataExp)
 		return errors.New("CheckTx")
 	}

--- a/types/protoreplace/protoreplace.go
+++ b/types/protoreplace/protoreplace.go
@@ -1,6 +1,6 @@
-package main
-
 // +build ignore
+
+package main
 
 import (
 	"bytes"


### PR DESCRIPTION
* Build tags need to come before the package name
and have at least a blank line, between them and
the package, please see
  https://golang.org/pkg/go/build/#hdr-Build_Constraints
* fmt.Println doesn't take formatting verbs
* Fix a missing formatting argument to fmt.Printf