### PR TITLE
protoc: "//nolint: gas" directive after pb generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ protoc:
 	##   ldconfig (may require sudo)
 	## https://stackoverflow.com/a/25518702
 	protoc $(INCLUDE) --gogo_out=plugins=grpc:. --lint_out=. types/*.proto
-	# Since protoc can't "//nolint: gas" our packages, we need to do it manually.
-	@ bash scripts/ducttape_nolint_protoc.sh
+	sed -i "/package types/ { N; s/package types\n/\/\/nolint: gas\n&/ }" types/*.pb.go
 
 install:
 	@ go install ./cmd/...

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ protoc:
 	##   ldconfig (may require sudo)
 	## https://stackoverflow.com/a/25518702
 	protoc $(INCLUDE) --gogo_out=plugins=grpc:. --lint_out=. types/*.proto
+	# Since protoc can't "//nolint: gas" our packages, we need to do it manually.
+	@ bash scripts/ducttape_nolint_protoc.sh
 
 install:
 	@ go install ./cmd/...

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ protoc:
 	##   ldconfig (may require sudo)
 	## https://stackoverflow.com/a/25518702
 	protoc $(INCLUDE) --gogo_out=plugins=grpc:. --lint_out=. types/*.proto
-	sed -i "/package types/ { N; s/package types\n/\/\/nolint: gas\n&/ }" types/*.pb.go
+	@echo "--> adding nolint declarations to protobuf generated files"
+	@awk '/package types/ { print "//nolint: gas"; print; next }1' types/types.pb.go > types/types.pb.go.new
+	@mv types/types.pb.go.new types/types.pb.go
 
 install:
 	@ go install ./cmd/...

--- a/scripts/ducttape_nolint_protoc.sh
+++ b/scripts/ducttape_nolint_protoc.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+grep -Rn 'package \(\w\+\)$' types/*.pb.go | cut -d':' -f1 | while read F;do backup="$F.bak";sed "s/package \([a-zA-Z]\{1,\}\)$/\/\/nolint: gas<NEWLINE_HEREXXXX>&/1" "$F" | awk -F"<NEWLINE_HEREXXXX>" '{ if (NF >= 2) { print $1"\n"$2 } else { print $1 } }' > "$backup";mv "$backup" "$F";done

--- a/scripts/ducttape_nolint_protoc.sh
+++ b/scripts/ducttape_nolint_protoc.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-grep -Rn 'package \(\w\+\)$' types/*.pb.go | cut -d':' -f1 | while read F;do backup="$F.bak";sed "s/package \([a-zA-Z]\{1,\}\)$/\/\/nolint: gas<NEWLINE_HEREXXXX>&/1" "$F" | awk -F"<NEWLINE_HEREXXXX>" '{ if (NF >= 2) { print $1"\n"$2 } else { print $1 } }' > "$backup";mv "$backup" "$F";done

--- a/types/types.pb.go
+++ b/types/types.pb.go
@@ -40,6 +40,7 @@ It has these top-level messages:
 	Evidence
 	KVPair
 */
+//nolint: gas
 package types
 
 import proto "github.com/gogo/protobuf/proto"


### PR DESCRIPTION
Fixes #138

Since we can't add package directives through the protoc
compiler, yet we need to "//nolint: gas" the Go generated
protobuf file, added a script whose purpose is to
go find the "package (\w+)$" declaration after go fmt
was run by protoc.

The competing solutions were more complex and can be
examined by visiting
https://github.com/tendermint/abci/issues/138#issuecomment-352226217