### PR TITLE
Proposal: New Makefile standard template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .glide
 types/types.pb.go
+*.sw[op]

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,56 @@
 GOTOOLS = \
-					github.com/mitchellh/gox \
-					github.com/Masterminds/glide \
-					gopkg.in/alecthomas/gometalinter.v2 \
-					github.com/gogo/protobuf/protoc-gen-gogo \
-					github.com/gogo/protobuf/gogoproto
-
+	github.com/mitchellh/gox \
+	github.com/Masterminds/glide \
+	gopkg.in/alecthomas/gometalinter.v2 \
+	github.com/gogo/protobuf/protoc-gen-gogo \
+	github.com/gogo/protobuf/gogoproto
+GOTOOLS_CHECK = gox glide gometalinter.v2 protoc protoc-gen-gogo
+PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gogo/protobuf/protobuf
 
-all: protoc install test metalinter
+all: check build test install metalinter
 
-PACKAGES=$(shell go list ./... | grep -v '/vendor/')
+check: check_tools get_vendor_deps
 
-install_protoc:
-	# https://github.com/google/protobuf/releases
+
+########################################
+###  Build
+
+protoc:
+	## If you get the following error,
+	## "error while loading shared libraries: libprotobuf.so.14: cannot open shared object file: No such file or directory"
+	## See https://stackoverflow.com/a/25518702
+	protoc $(INCLUDE) --gogo_out=plugins=grpc:. types/*.proto
+	@echo "--> adding nolint declarations to protobuf generated files"
+	@awk '/package types/ { print "//nolint: gas"; print; next }1' types/types.pb.go > types/types.pb.go.new
+	@mv types/types.pb.go.new types/types.pb.go
+
+build: protoc
+	@go build -i ./cmd/...
+
+dist:
+	@bash scripts/dist.sh
+	@bash scripts/publish.sh
+
+install:
+	@go install ./cmd/...
+
+
+########################################
+### Tools & dependencies
+
+check_tools:
+	@# https://stackoverflow.com/a/25668869
+	@echo "Found tools: $(foreach tool,$(GOTOOLS_CHECK),\
+        $(if $(shell which $(tool)),$(tool),$(error "No $(tool) in PATH")))"
+
+get_tools:
+	@echo "--> Installing tools"
+	go get -u -v $(GOTOOLS)
+	@gometalinter.v2 --install
+
+get_protoc:
+	@# https://github.com/google/protobuf/releases
 	curl -L https://github.com/google/protobuf/releases/download/v3.4.1/protobuf-cpp-3.4.1.tar.gz | tar xvz && \
 		cd protobuf-3.4.1 && \
 		DIST_LANG=cpp ./configure && \
@@ -21,60 +59,41 @@ install_protoc:
 		cd .. && \
 		rm -rf protobuf-3.4.1
 
-protoc:
-	## Note to self:
-	## On "error while loading shared libraries: libprotobuf.so.14: cannot open shared object file: No such file or directory"
-	##   ldconfig (may require sudo)
-	## https://stackoverflow.com/a/25518702
-	protoc $(INCLUDE) --gogo_out=plugins=grpc:. types/*.proto
-	@ echo "--> adding nolint declarations to protobuf generated files"
-	@ awk '/package types/ { print "//nolint: gas"; print; next }1' types/types.pb.go > types/types.pb.go.new
-	@ mv types/types.pb.go.new types/types.pb.go
+update_tools:
+	@echo "--> Updating tools"
+	@go get -u $(GOTOOLS)
 
-install:
-	@ go install ./cmd/...
+get_vendor_deps:
+	@rm -rf vendor/
+	@echo "--> Running glide install"
+	@glide install
 
-build:
-	@ go build -i ./cmd/...
 
-dist:
-	@ bash scripts/dist.sh
-	@ bash scripts/publish.sh
+########################################
+### Testing
 
 test:
-	@ find . -path ./vendor -prune -o -name "*.sock" -exec rm {} \;
-	@ echo "==> Running go test"
-	@ go test $(PACKAGES)
+	@find . -path ./vendor -prune -o -name "*.sock" -exec rm {} \;
+	@echo "==> Running go test"
+	@go test $(PACKAGES)
 
 test_race:
-	@ find . -path ./vendor -prune -o -name "*.sock" -exec rm {} \;
-	@ echo "==> Running go test --race"
-	@ go test -v -race $(PACKAGES)
+	@find . -path ./vendor -prune -o -name "*.sock" -exec rm {} \;
+	@echo "==> Running go test --race"
+	@go test -v -race $(PACKAGES)
 
 test_integrations:
-	@ bash test.sh
+	@bash test.sh
+
+
+########################################
+### Formatting, linting, and vetting
 
 fmt:
-	@ go fmt ./...
-
-get_deps:
-	@ go get -d $(PACKAGES)
-
-ensure_tools:
-	go get -u -v $(GOTOOLS)
-	@ gometalinter.v2 --install
-
-get_vendor_deps: ensure_tools
-	@ rm -rf vendor/
-	@ echo "--> Running glide install"
-	@ glide install
-
-metalinter_all:
-	protoc $(INCLUDE) --lint_out=. types/*.proto
-	gometalinter.v2 --vendor --deadline=600s --enable-all --disable=lll ./...
+	@go fmt ./...
 
 metalinter:
-	@ echo "==> Running linter"
+	@echo "==> Running linter"
 	gometalinter.v2 --vendor --deadline=600s --disable-all  \
 		--enable=maligned \
 		--enable=deadcode \
@@ -92,7 +111,6 @@ metalinter:
 		--enable=varcheck \
 		--enable=vetshadow \
 		./...
-
 		#--enable=gas \
 		#--enable=dupl \
 		#--enable=errcheck \
@@ -103,10 +121,22 @@ metalinter:
 		#--enable=unparam \
 		#--enable=vet \
 
-build-docker:
+metalinter_all:
+	protoc $(INCLUDE) --lint_out=. types/*.proto
+	gometalinter.v2 --vendor --deadline=600s --enable-all --disable=lll ./...
+
+
+########################################
+### Docker
+
+docker_build:
 	docker build -t "tendermint/abci-dev" -f Dockerfile.develop .
 
-run-docker:
+docker_run:
 	docker run -it --rm -v "$PWD:/go/src/github.com/tendermint/abci" -w "/go/src/github.com/tendermint/abci" "tendermint/abci-dev" /bin/bash
 
-.PHONY: all build test fmt get_deps ensure_tools protoc install_protoc build-docker run-docker
+
+# To avoid unintended conflicts with file names, always add to .PHONY
+# unless there is a reason not to.
+# https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
+.PHONY: check protoc build dist install check_tools get_tools get_protoc update_tools get_vendor_deps test test_race test_integrations fmt metalinter metalinter_all docker_build docker_run

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOTOOLS_CHECK = gox glide gometalinter.v2 protoc protoc-gen-gogo
 PACKAGES=$(shell go list ./... | grep -v '/vendor/')
 INCLUDE = -I=. -I=${GOPATH}/src -I=${GOPATH}/src/github.com/gogo/protobuf/protobuf
 
-all: check build test install metalinter
+all: check protoc build test install metalinter
 
 check: check_tools get_vendor_deps
 
@@ -25,7 +25,7 @@ protoc:
 	@awk '/package types/ { print "//nolint: gas"; print; next }1' types/types.pb.go > types/types.pb.go.new
 	@mv types/types.pb.go.new types/types.pb.go
 
-build: protoc
+build:
 	@go build -i ./cmd/...
 
 dist:

--- a/Makefile
+++ b/Makefile
@@ -129,14 +129,34 @@ metalinter_all:
 ########################################
 ### Docker
 
+DEVDOC_SAVE = docker commit `docker ps -a -n 1 -q` devdoc:local
+
 docker_build:
 	docker build -t "tendermint/abci-dev" -f Dockerfile.develop .
 
 docker_run:
-	docker run -it --rm -v "$PWD:/go/src/github.com/tendermint/abci" -w "/go/src/github.com/tendermint/abci" "tendermint/abci-dev" /bin/bash
+	docker run -it -v "$(CURDIR):/go/src/github.com/tendermint/abci" -w "/go/src/github.com/tendermint/abci" "tendermint/abci-dev" /bin/bash
+
+docker_run_rm:
+	docker run -it --rm -v "$(CURDIR):/go/src/github.com/tendermint/abci" -w "/go/src/github.com/tendermint/abci" "tendermint/abci-dev" /bin/bash
+
+devdoc_init:
+	docker run -it -v "$(CURDIR):/go/src/github.com/tendermint/abci" -w "/go/src/github.com/tendermint/abci" tendermint/devdoc echo
+	# TODO make this safer
+	$(call DEVDOC_SAVE)
+
+devdoc:
+	docker run -it -v "$(CURDIR):/go/src/github.com/tendermint/abci" -w "/go/src/github.com/tendermint/abci" devdoc:local bash
+
+devdoc_save:
+	# TODO make this safer
+	$(call DEVDOC_SAVE)
+
+devdoc_clean:
+	docker rmi $$(docker images -f "dangling=true" -q)
 
 
 # To avoid unintended conflicts with file names, always add to .PHONY
 # unless there is a reason not to.
 # https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
-.PHONY: check protoc build dist install check_tools get_tools get_protoc update_tools get_vendor_deps test test_race test_integrations fmt metalinter metalinter_all docker_build docker_run
+.PHONY: check protoc build dist install check_tools get_tools get_protoc update_tools get_vendor_deps test test_race test_integrations fmt metalinter metalinter_all docker_build docker_run docker_run_rm devdoc_init devdoc devdoc_save devdoc_clean

--- a/README.md
+++ b/README.md
@@ -200,5 +200,3 @@ Here, we describe the requests and responses as function arguments and return va
     * `Log (string)`: Debug or error message
   * __Usage__:<br/>
     Return a Merkle root hash of the application state.
-
-# devdoc

--- a/README.md
+++ b/README.md
@@ -201,3 +201,4 @@ Here, we describe the requests and responses as function arguments and return va
   * __Usage__:<br/>
     Return a Merkle root hash of the application state.
 
+# devdoc

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ checkout:
 
 test:
   override:
-    - cd $REPO && make get_vendor_deps && make metalinter && make test_integrations
+    - cd $REPO && make check build test_integrations
   post:
     - cd "$REPO" && bash <(curl -s https://codecov.io/bash) -f coverage.txt
     - cd "$REPO" && mv coverage.txt "${CIRCLE_ARTIFACTS}"

--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ checkout:
 
 test:
   override:
-    - cd $REPO && make check build test_integrations
+    - cd $REPO && make get_tools check build test_integrations
   post:
     - cd "$REPO" && bash <(curl -s https://codecov.io/bash) -f coverage.txt
     - cd "$REPO" && mv coverage.txt "${CIRCLE_ARTIFACTS}"


### PR DESCRIPTION
Lets use these conventions for Makefiles.  I've got a similar one for tendermint/tendermint.

Note the order for `all:` which gets run when you type `make`.

> check build test install metalinter

Check checks stuff without making side effects.  If there are tools that need to be installed, it yells at the user.  The user then has to run `make get_tools` manually, then type `make` again.

The build step quickly ensures that the project can actually compile.  Protoc and other file generations happen there as well.  Then you run the tests.  The tests may rely on the build step so this separation is important.

Installation should happen after tests pass.

The metalinter comes last.  It takes forever to run and it's annoying.  I don't mind if it hangs around on my terminal after I'm done though, so there it goes.