### PR TITLE
Fix string formatting error for go1.10

### DIFF
--- a/tests/server/client.go
+++ b/tests/server/client.go
@@ -34,7 +34,7 @@ func SetOption(client abcicli.Client, key, value string) error {
 	_, err := client.SetOptionSync(types.RequestSetOption{Key: key, Value: value})
 	if err != nil {
 		fmt.Println("Failed test: SetOption")
-		fmt.Printf("error while setting %v=%v: \nerror: %v\n", key, value)
+		fmt.Printf("error while setting %v=%v: \nerror: %v\n", key, value, err)
 		return err
 	}
 	fmt.Println("Passed test: SetOption")


### PR DESCRIPTION
Fix for string formatting error for go1.10