### PR TITLE
types: compile time assert to, and document sort.Interface

### DIFF
--- a/types/util.go
+++ b/types/util.go
@@ -3,12 +3,21 @@ package types
 import (
 	"bytes"
 	"encoding/json"
+	"sort"
 )
 
 //------------------------------------------------------------------------------
 
 // Validators is a list of validators that implements the Sort interface
 type Validators []Validator
+
+var _ sort.Interface = (Validators)(nil)
+
+// All these methods for Validators:
+//    Len, Less and Swap
+// are for Validators to implement sort.Interface
+// which will be used by the sort package.
+// See Issue https://github.com/tendermint/abci/issues/212
 
 func (v Validators) Len() int {
 	return len(v)


### PR DESCRIPTION
Fixes #212

Declare the purpose of the Less, Len, Swap methods
so that readers can see why they are defined.

Raised by an auditor in their report, as it looked like a security
concern but actually sort.Interface requires those methods implemented.