### PR TITLE
fix cli test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,23 @@ jobs:
             export PATH="$GOBIN:$PATH"
             bash tests/test_app/test.sh
 
+# XXX: if this test fails, fix it and update the docs at:
+# https://github.com/tendermint/tendermint/blob/develop/docs/abci-cli.rst
+  test_cli:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - restore_cache:
+          key: v1-pkg-cache
+      - restore_cache:
+          key: v1-tree-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Run cli tests
+          command: |
+            export PATH="$GOBIN:$PATH"
+            bash tests/test_cli/test.sh
+
   test_cover:
     <<: *defaults
     parallelism: 4
@@ -112,6 +129,9 @@ workflows:
           requires:
             - setup_dependencies
       - test_apps:
+          requires:
+            - setup_dependencies
+      - test_cli:
           requires:
             - setup_dependencies
       - upload_coverage:

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,11 @@ test_apps:
 	@ bash tests/test_app/test.sh
 
 test_cli:
-	# test the cli against the examples in the tutorial at tendermint.com
+	# test the cli against the examples in the tutorial at:
+	# http://tendermint.readthedocs.io/projects/tools/en/master/abci-cli.html
+	#
+	# XXX: if this test fails, fix it and update the docs at:
+	# https://github.com/tendermint/tendermint/blob/develop/docs/abci-cli.rst
 	@ bash tests/test_cli/test.sh
 
 ########################################

--- a/tests/test_cli/ex1.abci.out
+++ b/tests/test_cli/ex1.abci.out
@@ -10,6 +10,7 @@
 
 > commit 
 -> code: OK
+-> data.hex: 0x0000000000000000
 
 > deliver_tx "abc"
 -> code: OK
@@ -21,7 +22,7 @@
 
 > commit 
 -> code: OK
--> data.hex: 0x49DFD15CCDACDEAE9728CB01FBB5E8688CA58B91
+-> data.hex: 0x0200000000000000
 
 > query "abc"
 -> code: OK
@@ -35,7 +36,7 @@
 
 > commit 
 -> code: OK
--> data.hex: 0x70102DB32280373FBF3F9F89DA2A20CE2CD62B0B
+-> data.hex: 0x0400000000000000
 
 > query "def"
 -> code: OK

--- a/tests/test_cli/ex2.abci.out
+++ b/tests/test_cli/ex2.abci.out
@@ -1,5 +1,6 @@
 > set_option serial on
 -> code: OK
+-> log: OK (SetOption doesn't return anything.)
 
 > check_tx 0x00
 -> code: OK


### PR DESCRIPTION
- closes #244, relates to https://github.com/tendermint/tendermint/pull/1635
- tests the cli documentation, which needs updating (forthcoming in tendemint core)
- everytime this test fails (b/c output was changed in one of the `abci-cli` commands), it needs to be fixed (duh!) but also the docs need to be updated in tendermint. Hopefully should happen less and less as abci stabilizes.